### PR TITLE
remove comma in function

### DIFF
--- a/quickpost.php
+++ b/quickpost.php
@@ -29,7 +29,7 @@ function createwithrani_quickpost_script() {
 		'createwithrani-quickpost-js',
 		plugins_url( $index_js, __FILE__ ),
 		$asset_file['dependencies'],
-		$asset_file['version'],
+		$asset_file['version']
 	);
 	wp_set_script_translations( 'createwithrani-quickpost-js' );
 	wp_enqueue_style(


### PR DESCRIPTION
Fixes the issue reported in [this support ticket](https://wordpress.org/support/topic/fatal-error-4092/).