### PR TITLE
Add a Display filter to allow folks to filter the visibility of QuickPost

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,6 @@ addFilter(
 	"my-plugin/only-admins-quickpost",
 	onlyAdmins
 );
-
-
-
 ```
 ## Thanks these lovely humans!
 This was an odd duck, although relatively easy to make. I truly appreciate people taking time out of their day to test and give me feedback so I could make this tiny but handy plugin great. Major props to @sc0ttkclark, @treadlightly, and @christinaworkman for all their help! 💟

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![QuickPost](https://github.com/createwithrani/add-new-post/blob/main/assets/banner-1544x500.png?raw=true)
 
 Adds an "Add New" button to the Block Editor (Gutenberg) toolbar, so you can easily create new posts/pages/custom post types without leaving Fullscreen Mode in the editor. A kebab menu on the button allows you to duplicate the current post as well.
-## Description
+## About
 
 A razor sharp plugin that does just one thing: allow you to quickly create new posts from the Block Editor toolbar. You can create new posts in one of two ways:
 
@@ -20,7 +20,7 @@ If you have a feature request, please create an issue in the [GitHub repository]
 
 If you need support, please use the support forum to reach out. 🆘
 
-## Key Features
+### Key Features
 
 * A disabled button is available in the toolbar in brand new posts
 * The "Add New" button becomes clickable once your post's status is auto-draft, draft, pending, published, or any other state except new.
@@ -29,11 +29,49 @@ If you need support, please use the support forum to reach out. 🆘
 ### Upcoming Features
 
 * A handy shortcut to create new posts from your keyboard when in the block editor
-* Developers: the ability to filter the button's visibility
-## Requirements
+### Requirements
 
 - WordPress 5.8+
 - PHP 7.0+
 
+## Filtering QuickPost Visibility
+
+As of v0.1.3, you can filter the visibilty of the entire QuickPost button using the filter `QuickPostDisplay`. QuickPost has a property called `visibility`, which you can set to `true` or `false` depending on a condition of your choosing.
+
+### Example: Only allow Administrators to see the button:
+
+```js
+import { addFilter } from "@wordpress/hooks";
+import { useSelect } from "@wordpress/data";
+import { store as coreStore } from "@wordpress/core-data";
+
+function onlyAdmins(FilteredComponent) {
+	const adminUser = () => {
+		const { isAdmin } = useSelect((select) => {
+			const { canUser } = select(coreStore);
+			// check if current user can create users, because only admins can do that
+			const isAdmin = canUser("create", "users"); // returns undefined, true, or false
+			return {
+				isAdmin: isAdmin,
+			};
+		});
+		return isAdmin;
+	};
+	return (props) => (
+		<>
+			<FilteredComponent {...props} visibility={adminUser()} />
+		</>
+	);
+}
+
+addFilter(
+	"QuickPostDisplay",
+	"my-plugin/only-admins-quickpost",
+	onlyAdmins
+);
+
+
+
+```
 ## Thanks these lovely humans!
 This was an odd duck, although relatively easy to make. I truly appreciate people taking time out of their day to test and give me feedback so I could make this tiny but handy plugin great. Major props to @sc0ttkclark, @treadlightly, and @christinaworkman for all their help! 💟

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you need support, please use the support forum to reach out. 🆘
 
 ## Filtering QuickPost Visibility
 
-As of v0.1.3, you can filter the visibilty of the entire QuickPost button using the filter `QuickPostDisplay`. QuickPost has a property called `visibility`, which you can set to `true` or `false` depending on a condition of your choosing.
+As of v0.1.2, you can filter the visibilty of the entire QuickPost button using the filter `QuickPost.Display`. QuickPost has a property called `visibility`, which you can set to `true` or `false` depending on a condition of your choosing.
 
 ### Example: Only allow Administrators to see the button:
 
@@ -65,7 +65,7 @@ function onlyAdmins(FilteredComponent) {
 }
 
 addFilter(
-	"QuickPostDisplay",
+	"QuickPost.Display",
 	"my-plugin/only-admins-quickpost",
 	onlyAdmins
 );

--- a/readme.txt
+++ b/readme.txt
@@ -36,7 +36,6 @@ If you need support, please use the support forum to reach out. 🆘
 ### Upcoming Features
 
 * A handy shortcut to create new posts from your keyboard when in the block editor
-* Developers: the ability to filter the button's visibility
 
 === Stay Connected ===
 
@@ -54,6 +53,8 @@ If you need support, please use the support forum to reach out. 🆘
 Yes, this plugin is actively supported. If you have a question, issue, or you've identified a bug, please reach out through the support forums.
 = What gets duplicated? =
 Right now all _default_ WordPress post information gets duplicated, except featured images. Currently, custom taxonomies, Yoast information, or custom additions are not supported. But as the plugin evolves, more support will be added. Please use the support forums to let us know what you'd like added support for.
+= How can I change when QuickPost is available? =
+The plugin provides a filter called `QuickPostDisplay` to help you affect QuickPost's visibility. Refer to the example in the [README on GitHub](https://github.com/createwithrani/quickpost/tree/main#filtering-quickpost-visibilitys).
 
 == Screenshots ==
 
@@ -64,10 +65,10 @@ Right now all _default_ WordPress post information gets duplicated, except featu
 
 == Changelog ==
 
-= 0.1.1 =
-February 27, 2022
+= 0.1.1 - February 27, 2022 =
+
 * Fixes a small bug that causes a fatal error on installs running PHP versions lower than PHP 7.3
 
-= 0.1.0 =
-February 21, 2022
+= 0.1.0 - February 21, 2022 =
+
 * Release

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ subscribe(() => {
 		editorToolbar.appendChild(buttonWrapper);
 
 		render(
-			<QuickPostButton />,
+			<QuickPostButton visibility={true} />,
 			document.getElementById("createwithrani-quick-post-button-wrapper")
 		);
 	});

--- a/src/quick-post.js
+++ b/src/quick-post.js
@@ -43,7 +43,7 @@ function QuickPostButton({ visibility }) {
 	}
 	return null;
 }
-const QuickPostButtoWithFilters = withFilters("QuickPostDisplay")(
+const QuickPostButtoWithFilters = withFilters("QuickPost.Display")(
 	QuickPostButton
 );
 export default QuickPostButtoWithFilters;

--- a/src/quick-post.js
+++ b/src/quick-post.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { withFilters } from "@wordpress/components";
+
+/**
  * Internal dependencies.
  */
 import { getPostInfo, getPostLabels, getPostTypeRestBase } from "./utils";
@@ -11,7 +16,7 @@ import QuickPostKebabMenu from "./kebab-menu";
  * @since 0.1.0
  * @return {string} Return the rendered Quick Post Button
  */
-function QuickPostButton() {
+function QuickPostButton({ visibility }) {
 	const { postType, newPost } = getPostInfo();
 	if (!postType) {
 		return null;
@@ -19,7 +24,7 @@ function QuickPostButton() {
 	const { addNewLabel, singleLabel } = getPostLabels(postType);
 	const restBase = getPostTypeRestBase(postType);
 	// Until we get the label info back, we don't want to render the button.
-	if (undefined !== addNewLabel && undefined !== restBase) {
+	if (undefined !== addNewLabel && undefined !== restBase && visibility) {
 		return (
 			<>
 				<AddNewPostButton
@@ -38,5 +43,7 @@ function QuickPostButton() {
 	}
 	return null;
 }
-
-export default QuickPostButton;
+const QuickPostButtoWithFilters = withFilters("QuickPostDisplay")(
+	QuickPostButton
+);
+export default QuickPostButtoWithFilters;


### PR DESCRIPTION
This PR closes #4, and adds a new prop to the `QuickPostButton` component called `visibility`, as well as wrapping that component in `WithFilters` to allow filtering with `addFilter` by other people.

The updated README includes an example on how to change when QuickPost is visible using the filter.

```js
import { addFilter } from "@wordpress/hooks";
import { useSelect } from "@wordpress/data";
import { store as coreStore } from "@wordpress/core-data";

function onlyAdmins(FilteredComponent) {
	const adminUser = () => {
		const { isAdmin } = useSelect((select) => {
			const { canUser } = select(coreStore);
			// check if current user can create users, because only admins can do that
			const isAdmin = canUser("create", "users"); // returns undefined, true, or false
			return {
				isAdmin: isAdmin,
			};
		});
		return isAdmin;
	};
	return (props) => (
		<>
			<FilteredComponent {...props} visibility={adminUser()} />
		</>
	);
}

addFilter(
	"QuickPostDisplay",
	"my-plugin/only-admins-quickpost",
	onlyAdmins
);
```