### PR TITLE
Changing the behaviour of QuickPost

### DIFF
--- a/src/add-button.js
+++ b/src/add-button.js
@@ -13,8 +13,8 @@ import { addQueryArgs } from "@wordpress/url";
  */
 function AddNewPostButton({ postType, newPost, addNewLabel, singleLabel }) {
 	return (
-		<ToolbarButton
-			isSecondary
+		<a
+			className="components-button components-toolbar__control is-secondary"
 			id="createwithrani-quick-post-button"
 			style={{
 				textTransform: "capitalize",
@@ -26,13 +26,12 @@ function AddNewPostButton({ postType, newPost, addNewLabel, singleLabel }) {
 				borderTopRightRadius: "0px",
 				borderBottomRightRadius: "0px",
 			}}
+			role="link"
 			disabled={!newPost}
 			aria-disabled={!newPost}
-			onClick={() =>
-				(location.href = addQueryArgs("post-new.php", {
-					post_type: postType,
-				}))
-			}
+			href={addQueryArgs("post-new.php", {
+				post_type: postType,
+			})}
 		>
 			<span>
 				{sprintf(
@@ -41,7 +40,7 @@ function AddNewPostButton({ postType, newPost, addNewLabel, singleLabel }) {
 					singleLabel
 				)}
 			</span>
-		</ToolbarButton>
+		</a>
 	);
 }
 

--- a/src/duplicate-menu-item.js
+++ b/src/duplicate-menu-item.js
@@ -59,7 +59,11 @@ export function DuplicateMenuItem({ singleLabel, restBase }) {
 						action: "edit",
 					})}
 				>
-					View Post
+					{sprintf(
+						/* translators: %s: singular label of current post type i.e Page, Post */
+						__("View %s", "createwithrani-quickpost"),
+						singleLabel
+					)}
 				</a>
 			</div>
 		);

--- a/src/duplicate-menu-item.js
+++ b/src/duplicate-menu-item.js
@@ -62,7 +62,7 @@ export function DuplicateMenuItem({ singleLabel, restBase }) {
 			>
 				{sprintf(
 					/* translators: %s: singular label of current post type i.e Page, Post */
-					__("View duplicated %s", "createwithrani-quickpost"),
+					__("Edit duplicated %s", "createwithrani-quickpost"),
 					singleLabel
 				)}
 			</ToolbarItem>

--- a/src/duplicate-menu-item.js
+++ b/src/duplicate-menu-item.js
@@ -37,10 +37,14 @@ export function DuplicateMenuItem({ singleLabel, restBase }) {
 	};
 	useEffect(() => {
 		if (0 !== postId) {
-			location.href = addQueryArgs("post.php", {
-				post: postId,
-				action: "edit",
-			});
+			window.open(
+				addQueryArgs("post.php", {
+					post: postId,
+					action: "edit",
+				}),
+				"_blank"
+			);
+			setDuplicationStatus(false);
 		}
 	}, [postId]);
 

--- a/src/duplicate-menu-item.js
+++ b/src/duplicate-menu-item.js
@@ -52,38 +52,44 @@ export function DuplicateMenuItem({ singleLabel, restBase }) {
 
 	const ViewDuplicatedPost = () => {
 		return (
-			<div>
+			<ToolbarItem
+				as={MenuItem}
+				className="createwithrani-quick-post-duplicate-menu-item"
+			>
+				{sprintf(
+					/* translators: %s: singular label of current post type i.e Page, Post */
+					__("%s duplicated", "createwithrani-quickpost"),
+					singleLabel
+				)}
 				<a
 					href={addQueryArgs("post.php", {
 						post: postId,
 						action: "edit",
 					})}
 				>
-					{sprintf(
-						/* translators: %s: singular label of current post type i.e Page, Post */
-						__("View %s", "createwithrani-quickpost"),
-						singleLabel
-					)}
+					{__("View", "createwithrani-quickpost")}
 				</a>
-			</div>
+			</ToolbarItem>
 		);
 	};
 	return (
 		<>
-			<ToolbarItem
-				as={MenuItem}
-				className="createwithrani-quick-post-duplicate-menu-item"
-			>
-				<span onClick={DuplicateThePost}>
+			{0 === postId && (
+				<ToolbarItem
+					onClick={DuplicateThePost}
+					as={MenuItem}
+					className="createwithrani-quick-post-duplicate-menu-item"
+				>
 					{sprintf(
 						/* translators: %s: singular label of current post type i.e Page, Post */
 						__("Duplicate %s", "createwithrani-quickpost"),
 						singleLabel
 					)}
-				</span>
-				{0 !== postId && <ViewDuplicatedPost />}
-				{duplicationStatus && <Spinner />}
-			</ToolbarItem>
+
+					{duplicationStatus && <Spinner />}
+				</ToolbarItem>
+			)}
+			{0 !== postId && <ViewDuplicatedPost />}
 		</>
 	);
 }

--- a/src/duplicate-menu-item.js
+++ b/src/duplicate-menu-item.js
@@ -53,22 +53,18 @@ export function DuplicateMenuItem({ singleLabel, restBase }) {
 	const ViewDuplicatedPost = () => {
 		return (
 			<ToolbarItem
-				as={MenuItem}
-				className="createwithrani-quick-post-duplicate-menu-item"
+				as="a"
+				href={addQueryArgs("post.php", {
+					post: postId,
+					action: "edit",
+				})}
+				className="components-button components-dropdown-menu__toggle is-secondary"
 			>
 				{sprintf(
 					/* translators: %s: singular label of current post type i.e Page, Post */
-					__("%s duplicated", "createwithrani-quickpost"),
+					__("View duplicated %s", "createwithrani-quickpost"),
 					singleLabel
 				)}
-				<a
-					href={addQueryArgs("post.php", {
-						post: postId,
-						action: "edit",
-					})}
-				>
-					{__("View", "createwithrani-quickpost")}
-				</a>
 			</ToolbarItem>
 		);
 	};

--- a/src/duplicate-menu-item.js
+++ b/src/duplicate-menu-item.js
@@ -72,23 +72,26 @@ export function DuplicateMenuItem({ singleLabel, restBase }) {
 			</ToolbarItem>
 		);
 	};
+	const DuplicatePostButton = () => {
+		return (
+			<ToolbarItem
+				onClick={DuplicateThePost}
+				as={MenuItem}
+				className="createwithrani-quick-post-duplicate-menu-item"
+			>
+				{sprintf(
+					/* translators: %s: singular label of current post type i.e Page, Post */
+					__("Duplicate %s", "createwithrani-quickpost"),
+					singleLabel
+				)}
+
+				{duplicationStatus && <Spinner />}
+			</ToolbarItem>
+		);
+	};
 	return (
 		<>
-			{0 === postId && (
-				<ToolbarItem
-					onClick={DuplicateThePost}
-					as={MenuItem}
-					className="createwithrani-quick-post-duplicate-menu-item"
-				>
-					{sprintf(
-						/* translators: %s: singular label of current post type i.e Page, Post */
-						__("Duplicate %s", "createwithrani-quickpost"),
-						singleLabel
-					)}
-
-					{duplicationStatus && <Spinner />}
-				</ToolbarItem>
-			)}
+			{0 === postId && <DuplicatePostButton />}
 			{0 !== postId && <ViewDuplicatedPost />}
 		</>
 	);

--- a/src/duplicate-menu-item.js
+++ b/src/duplicate-menu-item.js
@@ -5,7 +5,7 @@ import apiFetch from "@wordpress/api-fetch";
 import { __ } from "@wordpress/i18n";
 import { MenuItem, ToolbarItem } from "@wordpress/components";
 import { useSelect } from "@wordpress/data";
-import { useEffect, useState } from "@wordpress/element";
+import { useState } from "@wordpress/element";
 import { Spinner } from "@wordpress/components";
 import { addQueryArgs } from "@wordpress/url";
 
@@ -35,18 +35,6 @@ export function DuplicateMenuItem({ singleLabel, restBase }) {
 		meta: currentPostData.meta,
 		template: currentPostData.template,
 	};
-	useEffect(() => {
-		if (0 !== postId) {
-			window.open(
-				addQueryArgs("post.php", {
-					post: postId,
-					action: "edit",
-				}),
-				"_blank"
-			);
-			setDuplicationStatus(false);
-		}
-	}, [postId]);
 
 	const fetchData = async () => {
 		const response = await apiFetch({
@@ -55,24 +43,43 @@ export function DuplicateMenuItem({ singleLabel, restBase }) {
 			data: DuplicatePost,
 		});
 		setPostId(response.id);
+		setDuplicationStatus(false);
 	};
 	function DuplicateThePost() {
 		setDuplicationStatus(true);
 		fetchData();
 	}
-	return (
-		<ToolbarItem
-			as={MenuItem}
-			onClick={DuplicateThePost}
-			className="createwithrani-quick-post-duplicate-menu-item"
-		>
-			{sprintf(
-				/* translators: %s: singular label of current post type i.e Page, Post */
-				__("Duplicate %s", "createwithrani-quickpost"),
-				singleLabel
-			)}
 
-			{duplicationStatus && <Spinner />}
-		</ToolbarItem>
+	const ViewDuplicatedPost = () => {
+		return (
+			<div>
+				<a
+					href={addQueryArgs("post.php", {
+						post: postId,
+						action: "edit",
+					})}
+				>
+					View Post
+				</a>
+			</div>
+		);
+	};
+	return (
+		<>
+			<ToolbarItem
+				as={MenuItem}
+				className="createwithrani-quick-post-duplicate-menu-item"
+			>
+				<span onClick={DuplicateThePost}>
+					{sprintf(
+						/* translators: %s: singular label of current post type i.e Page, Post */
+						__("Duplicate %s", "createwithrani-quickpost"),
+						singleLabel
+					)}
+				</span>
+				{0 !== postId && <ViewDuplicatedPost />}
+				{duplicationStatus && <Spinner />}
+			</ToolbarItem>
+		</>
 	);
 }

--- a/src/kebab-menu.js
+++ b/src/kebab-menu.js
@@ -6,7 +6,7 @@ import classnames from "classnames";
 /**
  * WordPress dependencies.
  */
-import { ToolbarDropdownMenu } from "@wordpress/components";
+import { DropdownMenu } from "@wordpress/components";
 import { moreVertical } from "@wordpress/icons";
 
 /**
@@ -45,7 +45,7 @@ function QuickPostKebabMenu({ newPost, restBase, singleLabel }) {
 
 	return (
 		<>
-			<ToolbarDropdownMenu
+			<DropdownMenu
 				className="createwithrani-quick-post-kebab"
 				popoverProps={POPOVER_PROPS}
 				toggleProps={toggleProps}
@@ -57,7 +57,7 @@ function QuickPostKebabMenu({ newPost, restBase, singleLabel }) {
 						restBase={restBase}
 					/>
 				)}
-			</ToolbarDropdownMenu>
+			</DropdownMenu>
 		</>
 	);
 }


### PR DESCRIPTION
Closes #17 

This PR transforms the `Add New` button into a true semantic link to allow folks to open the new post in the current tab/window, new tab, or new window.

It also introduced an improved user experience for duplicating posts: 

When you choose to duplicate a post, on success, not only does the entire menu item transforms into a semantic link (for the same benefits as the `add new` button transformation, but also with the call to action `Edit duplicated {post type label}`, to correctly indicate they'll be taken to the editor for the newly duplicated post.