### PR TITLE
Fix/common css file enqueue

### DIFF
--- a/quickpost.php
+++ b/quickpost.php
@@ -44,4 +44,4 @@ function createwithrani_quickpost_script() {
 }
 
 add_action( 'enqueue_block_editor_assets', 'createwithrani_quickpost_script' );
-add_action( 'init', 'createwithrani_quickpost_script' );
+// add_action( 'init', 'createwithrani_quickpost_script' );

--- a/quickpost.php
+++ b/quickpost.php
@@ -44,4 +44,3 @@ function createwithrani_quickpost_script() {
 }
 
 add_action( 'enqueue_block_editor_assets', 'createwithrani_quickpost_script' );
-// add_action( 'init', 'createwithrani_quickpost_script' );


### PR DESCRIPTION
Fixes #21 

Remove init hook for QuickPost enqueue. It seems the bug for which this was added is no longer an issue and translations are working properly again. So it looks like we can safely remove this now!