### PR TITLE
Adding new post shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@ If you need support, please use the support forum to reach out. 🆘
 * A disabled button is available in the toolbar in brand new posts
 * The "Add New" button becomes clickable once your post's status is auto-draft, draft, pending, published, or any other state except new.
 * You can duplicate the current post with two clicks.
+* A keyboard shortcut to create a new post directly from your keyboard (Ctrl + Option + N on Mac or Alt + Shift + N on Windows)
 
-### Upcoming Features
-
-* A handy shortcut to create new posts from your keyboard when in the block editor
 ### Requirements
 
 - WordPress 5.8+

--- a/readme.txt
+++ b/readme.txt
@@ -32,10 +32,7 @@ If you need support, please use the support forum to reach out. 🆘
 * A disabled button is available in the toolbar in brand new posts
 * The "Add New" button becomes clickable once your post's status is auto-draft, draft, pending, published, or any other state except new.
 * You can duplicate the current post with two clicks.
-
-### Upcoming Features
-
-* A handy shortcut to create new posts from your keyboard when in the block editor
+* A keyboard shortcut to create a new post directly from your keyboard (Ctrl + Option + N on Mac or Alt + Shift + N on Windows)
 
 === Stay Connected ===
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import domReady from "@wordpress/dom-ready";
  * Internal dependencies.
  */
 import QuickPostButton from "./quick-post";
+import { listenForKeyboardShortcut } from "./utils";
 
 /**
  * Let's subscribe (because I finally understand what this does better)
@@ -49,3 +50,5 @@ subscribe(() => {
 		);
 	});
 });
+
+document.addEventListener('keydown', listenForKeyboardShortcut);

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,8 +75,8 @@ export function listenForKeyboardShortcut(event) {
 	if (
 		// Shortcut for Mac (Ctrl + Option + N)
 		(event.ctrlKey && event.altKey && 78 === event.keyCode) ||
-		// Shortcut for Windows (Ctrl + Shift + N)
-		(event.ctrlKey && event.shiftKey && 78 === event.keyCode)
+		// Shortcut for Windows (Alt + Shift + N)
+		(event.altKey && event.shiftKey && 78 === event.keyCode)
 	) {
         event.preventDefault();
     	document.querySelector('#createwithrani-quick-post-button').click();

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,6 @@
 import { __ } from "@wordpress/i18n";
 import { useSelect } from "@wordpress/data";
 import { store as coreStore } from "@wordpress/core-data";
-import { addQueryArgs } from "@wordpress/url";
 
 /*
  * 	We need to know two things:

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@
 import { __ } from "@wordpress/i18n";
 import { useSelect } from "@wordpress/data";
 import { store as coreStore } from "@wordpress/core-data";
+import { addQueryArgs } from "@wordpress/url";
 
 /*
  * 	We need to know two things:
@@ -68,4 +69,16 @@ export function getPostTypeRestBase(postType) {
 		};
 	});
 	return rest_base;
+}
+
+export function listenForKeyboardShortcut(event) {
+	if (
+		// Shortcut for Mac (Ctrl + Option + N)
+		(event.ctrlKey && event.altKey && 78 === event.keyCode) ||
+		// Shortcut for Windows (Ctrl + Shift + N)
+		(event.ctrlKey && event.shiftKey && 78 === event.keyCode)
+	) {
+        event.preventDefault();
+    	document.querySelector('#createwithrani-quick-post-button').click();
+    }
 }


### PR DESCRIPTION
This is the first pass at adding a new post shortcut as identified in #2.

Because there seems to be [some precedent](https://wordpress.org/support/article/keyboard-shortcuts/#alt-shift-key) with using Ctrl + Option (Mac) and Alt + Shift (Windows) for shortcuts in the WordPress editor, I've opted for `Ctrl + Option + N` to be the Mac shortcut and `Alt + Shift + N` to be the Windows shortcut.

This code listens for either of those key combinations to be pressed and then clicks the existing New Post button. This may be possible to use `window.location.href` or something like that instead of simulating a click (especially if #7 gets merged and the button isn't always new post), but I think it should work for now.